### PR TITLE
deploy落ち解消。users-permissionsプラグインに必要なJWT_SECRETの設定追加

### DIFF
--- a/config/plugins.ts
+++ b/config/plugins.ts
@@ -1,1 +1,7 @@
-export default () => ({});
+module.exports = ({ env }) => ({
+  "users-permissions": {
+    config: {
+      jwtSecret: env('JWT_SECRET'),
+    },
+  },
+});


### PR DESCRIPTION
エラー内容：
Error: Missing jwtSecret. Please, set configuration variable "jwtSecret" for the users-permissions plugin in config/plugins.js (ex: you can generate one using Node with `crypto.randomBytes(16).toString('base64')`).